### PR TITLE
Simplify chess heatmap generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 credentials.json
+*.swp
+*.swo

--- a/chess/capture-map.js
+++ b/chess/capture-map.js
@@ -19,42 +19,44 @@ function renderGraph(data) {
   Plotly.newPlot(captureMap, graphData);
 }
 
-let matches = [];
-let squares = {};
-let coords = [];
-const regex = /x([a-hA-H][1-8])/gm;
+const regex = /x[a-hA-H][1-8]/gm;
 
 fetch(URL)
   .then((response) => response.text())
   .then((text) => {
-    for (m of text.matchAll(regex)) {
-      let square = m[1];
-      if (!squares[square]) {
-        squares[square] = 1;
-      } else {
-        squares[square] += 1;
+    // Set up the initial 2D array of squares, with each square having an
+    // initial value of zero. This way we are guaranteed to have exactly the
+    // right number of squares in the output.
+    let squares = []
+    for (let x = 0; x < 8; ++x) {
+      squares[x] = []
+      for (let y = 0; y < 8; ++y) {
+        squares[x][y] = 0;
       }
     }
 
-    const unsortedMap = new Map(Object.entries(squares));
-    const unsortedArray = [...unsortedMap];
+    // For each match, increment the correct square
+    let startXOrd = "a".codePointAt(0);
+    for (matches of text.matchAll(regex)) {
+      // There should only be one match, since we have no groups.  The first
+      // character is always 'x', so we ignore it. The second character (idx 1)
+      // is the X coordinate, and the third character (idx 2) is the Y
+      // coordinate.
+      let match = matches[0]
 
-    const sortedArray = unsortedArray.sort(([key1, value1], [key2, value2]) =>
-      key1.localeCompare(key2)
-    );
+      // We get the x index by determining the distance between the left-most
+      // square's letter ('a') and the letter for this match.
+      let x = match.codePointAt(1) - startXOrd
 
-    //const sortedMap = new Map(sortedArray);
+      // Y is already just a number, so parse it, then offset it so it's
+      // zero-indexed.
+      let y = Number(match[2]) - 1
 
-    coords = [];
-
-    for (let i = 0; i < sortedArray.length; i) {
-      let temp = [];
-      for (let j = 0; j < 8; j++) {
-        temp.push(sortedArray[i][1]);
-        i++;
-      }
-      coords.push(temp);
+      // console.log("match", match, "x", x, "y", y)
+      squares[x][y]++
     }
-    console.log("coords", coords);
-    renderGraph(coords);
+
+    console.log("squares", squares)
+    // Our data is already in the expected format
+    renderGraph(squares);
   });


### PR DESCRIPTION
### Context
Tomas and Ed worked on porting the chess heatmap to JS. 

### Problem
Tomas wants to simplify the generation code if possible. I enjoy this sort of thing, so I wanted to take a swing at simplifying it, too.

### Solution
After looking at Ed's and Tomas' solutions, I started out simplifying Tomas' algorithm. As I did so, I noticed a potential issue: if the target user on lichess does not have captures in every square, the generated grid will be missing one or more cells, and the heatmap won't render correctly. 

To resolve this, I build the whole 8x8 grid as a 2D array, with initial zero values in each cell. Then, I index to the correct cell (borrowing from Ed's cell-indexing methods) and increment it for each regex match (capture). The resulting data format is already in the expected form, so no additional data massaging is needed. This is effectively the same as Ed's solution, but more compact.

